### PR TITLE
fixed info content which was overlapping with logo

### DIFF
--- a/src/atomicui/pages/DemoPage/styles.scss
+++ b/src/atomicui/pages/DemoPage/styles.scss
@@ -164,6 +164,12 @@
 	background-image: url("@demo/assets/pngs/Loading.png");
 }
 
+@media only screen and (max-width: 760px) {
+	.mapboxgl-ctrl-attrib-inner {
+		margin-bottom: 25px;
+	}
+}
+
 @media only screen and (max-width: 640px) {
 	.maplibregl-ctrl-attrib-inner.mapboxgl-ctrl-attrib-inner {
 		margin-top: -20px;


### PR DESCRIPTION
Ticket: https://makeen.atlassian.net/browse/ALS-1258

<img width="556" alt="image" src="https://github.com/makeen-project/amazon-location-features-demo-web/assets/22417012/ff503ac8-79c2-414c-bb53-a2ab00844dfd">
