### PR TITLE
show connection banner when network is lost

### DIFF
--- a/src/atomicui/organisms/TrackerBox/TrackerBox.tsx
+++ b/src/atomicui/organisms/TrackerBox/TrackerBox.tsx
@@ -58,6 +58,8 @@ const TrackerBox: React.FC<TrackerBoxProps> = ({ mapRef, setShowTrackingBox }) =
 			flushTimeoutId = setTimeout(() => {
 				setHideConnectionAlert(true);
 			}, 3000);
+		} else {
+			setHideConnectionAlert(false);
 		}
 
 		return () => {


### PR DESCRIPTION
- When the connection was successful and then lost, the banner indicating the connection status was not visible. I am now working on reinstating this banner to show up whenever the connection is lost.